### PR TITLE
Show help on ? key

### DIFF
--- a/src/components/Help/index.css
+++ b/src/components/Help/index.css
@@ -18,6 +18,10 @@
 
 .help .bold {
     font-weight: bold;
+    font-family: monospace;
+    background-color: #e2e2e2;
+    border-radius: 2px;
+    padding: 0 2px;
 }
 
 .help .padding10 {

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -29,7 +29,7 @@ export const COMMANDS = {
         PAN_RIGHT: command('PAN_RIGHT', 'right', 'Pan right'),
         PAN_LEFT: command('PAN_LEFT', 'left', 'Pan left'),
         REST_PAN_ZOOM: command('RESET_PAN_ZOOM', '0', 'Reset pan and zoom to default'),
-        TOGGLE_HELP: command('TOOGLE_HELP', 'esc', 'Toggle help window'),
+        TOGGLE_HELP: command('TOOGLE_HELP', ['esc','?'], 'Toggle help window'),
         TOGGLE_SPLIT_BORDER_VISIBLE: command('TOGGLE_SPLIT_BORDER_VISIBLE', 's', 'Toggle split border visible')
 };
 


### PR DESCRIPTION
Many webapps/tools have the questionmark (`?`) key bound to show the other keyboard shortcuts.
That's definitely what I was expecting :)

---

okay i also tweaked the styles so the shortcuts stand out a tad: 
<img width="619" alt="image" src="https://github.com/user-attachments/assets/b4821f3b-2bc1-4cfc-8efd-92fdda129c65">
