### PR TITLE
Sort variants by bandwidth ascending to align with hls.js behavior

### DIFF
--- a/src/components/Help/index.css
+++ b/src/components/Help/index.css
@@ -11,7 +11,6 @@
     left: 50%;
 
     margin: -300px 0 0 -300px;
-    opacity: 0.5;
 
     border-radius: 10px;
 }

--- a/src/components/VideoViewer/VideoPlayer.js
+++ b/src/components/VideoViewer/VideoPlayer.js
@@ -118,7 +118,7 @@ class VideoPlayer extends Component {
         console.log(`setVariant: ${variant}`);
         if (this.state.dash) {
             this.state.dash.setQualityFor('video', variant);
-        } else if (this.state.hls) {
+        } else if (this.state.hls && this.state.hls.levels) {
             this.state.hls.currentLevel = Math.max(0, this.state.hls.levels.length - variant - 1);
         }
     }

--- a/src/components/VideoViewer/VideoPlayer.js
+++ b/src/components/VideoViewer/VideoPlayer.js
@@ -119,7 +119,7 @@ class VideoPlayer extends Component {
         if (this.state.dash) {
             this.state.dash.setQualityFor('video', variant);
         } else if (this.state.hls) {
-            this.state.hls.currentLevel = variant;
+            this.state.hls.currentLevel = this.state.hls.levels.length - variant - 1;
         }
     }
 
@@ -160,7 +160,7 @@ class VideoPlayer extends Component {
         }
         hls.loadSource(url);
         hls.attachMedia(this.videoElement);
-        hls.currentLevel = variant;
+        hls.currentLevel = hls.levels.length - variant - 1;
     }
 
     currentTime() {

--- a/src/components/VideoViewer/VideoPlayer.js
+++ b/src/components/VideoViewer/VideoPlayer.js
@@ -119,7 +119,7 @@ class VideoPlayer extends Component {
         if (this.state.dash) {
             this.state.dash.setQualityFor('video', variant);
         } else if (this.state.hls) {
-            this.state.hls.currentLevel = this.state.hls.levels.length - variant - 1;
+            this.state.hls.currentLevel = Math.max(0, this.state.hls.levels.length - variant - 1);
         }
     }
 
@@ -160,7 +160,7 @@ class VideoPlayer extends Component {
         }
         hls.loadSource(url);
         hls.attachMedia(this.videoElement);
-        hls.currentLevel = hls.levels.length - variant - 1;
+        hls.currentLevel = Math.max(0, hls.levels.length - variant - 1);
     }
 
     currentTime() {

--- a/src/components/VideoViewer/VideoPlayer.js
+++ b/src/components/VideoViewer/VideoPlayer.js
@@ -160,7 +160,13 @@ class VideoPlayer extends Component {
         }
         hls.loadSource(url);
         hls.attachMedia(this.videoElement);
-        hls.currentLevel = Math.max(0, hls.levels.length - variant - 1);
+        hls.once(Hls.Events.MANIFEST_LOADED, (_event, data) => {
+            if(!data.levels.length) {
+                console.error('No levels found in HLS manifest');
+                return;
+            }
+            hls.currentLevel = Math.max(0, data.levels.length - variant - 1);
+        });
     }
 
     currentTime() {

--- a/src/components/VideoViewer/index.css
+++ b/src/components/VideoViewer/index.css
@@ -63,22 +63,28 @@ video::-webkit-media-controls-enclosure {
 .big-play-button {
     position: absolute;
     display: flex;
-    color: white;
     align-items: center;
     justify-content: center;
-    top: 50%;
+    background: #000;
+    z-index: 15;
     left: 50%;
+    top: 50%;
     margin-left: -32px;
     margin-top: -32px;
-    border-radius: 32px;
+}
+
+.big-play-button:hover svg {
+    background: #fff;
+}
+
+.big-play-button svg {
     width: 64px;
+    border: 2px solid #fff;
+    border-radius: 100%;
     height: 64px;
-    line-height: 32px;
-    opacity: 0.8;
-    padding: 0;
-    background: black;
-    border: solid 2px white;
-    z-index: 15;
+    padding: 18px;
+    color: #ff0000;
+    cursor: pointer;
 }
 
 .big-play-button .hidden {
@@ -98,7 +104,7 @@ video::-webkit-media-controls-enclosure {
     border-radius: 1em;
     text-align: center;
     opacity: 0;
-    transition: opacity .5s ease-in-out;
+    transition: opacity 0.5s ease-in-out;
     transition-delay: 0;
     z-index: 14;
     width: 95%;
@@ -126,7 +132,7 @@ video::-webkit-media-controls-enclosure {
     fill: white;
 }
 
-input[type="range"] {
+input[type='range'] {
     width: 100%;
     -webkit-appearance: none;
     background: transparent;
@@ -135,9 +141,9 @@ input[type="range"] {
     margin-bottom: 4px;
 }
 
-input[type="range"]::-webkit-slider-thumb {
+input[type='range']::-webkit-slider-thumb {
     border: 2px solid white;
-    box-shadow: 0px 10px 10px rgba(0,0,0,0.25);
+    box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.25);
     height: 22px;
     width: 22px;
     border-radius: 11px;
@@ -147,9 +153,9 @@ input[type="range"]::-webkit-slider-thumb {
     margin-top: -9px;
 }
 
-input[type=range]::-moz-range-thumb {
+input[type='range']::-moz-range-thumb {
     border: 2px solid white;
-    box-shadow: 0px 10px 10px rgba(0,0,0,0.25);
+    box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.25);
     height: 22px;
     width: 22px;
     border-radius: 11px;
@@ -157,11 +163,11 @@ input[type=range]::-moz-range-thumb {
     cursor: pointer;
 }
 
-input[type=range]:focus {
+input[type='range']:focus {
     outline: none;
 }
 
-input[type=range]::-webkit-slider-runnable-track {
+input[type='range']::-webkit-slider-runnable-track {
     width: 100%;
     height: 8.4px;
     cursor: pointer;
@@ -170,7 +176,7 @@ input[type=range]::-webkit-slider-runnable-track {
     background: black;
 }
 
-input[type=range]::-moz-range-track {
+input[type='range']::-moz-range-track {
     width: 100%;
     height: 8.4px;
     cursor: pointer;
@@ -179,10 +185,9 @@ input[type=range]::-moz-range-track {
     background: black;
 }
 
-input[type=range]:focus::-webkit-slider-runnable-track {
+input[type='range']:focus::-webkit-slider-runnable-track {
     background: black;
 }
-
 
 .controls > button:before {
     position: relative;

--- a/src/components/VideoViewer/index.js
+++ b/src/components/VideoViewer/index.js
@@ -25,8 +25,8 @@ const DEFAULT_SOURCES = {
 
 const urlParams = new URLSearchParams(window.location.search);
 const DEFAULT_SOURCE = DEFAULT_SOURCES[urlParams.get('defaultSource') ? urlParams.get('defaultSource') : 'hls'];
-const leftVideoUrl = urlParams.get('leftVideoUrl') || DEFAULT_SOURCE;
-const rightVideoUrl = urlParams.get('rightVideoUrl') || leftVideoUrl;
+const leftVideoUrl = window.leftVideoUrl || urlParams.get('leftVideoUrl') || DEFAULT_SOURCE;
+const rightVideoUrl = window.rightVideoUrl || urlParams.get('rightVideoUrl') || leftVideoUrl;
 const leftVideoVariant = Number(urlParams.get('leftVideoVariant')) || 0;
 const rightVideoVariant = Number(urlParams.get('rightVideoVariant')) || 0;
 const startPosition = Number(urlParams.get('position')) || 0;
@@ -355,11 +355,11 @@ class VideoViewer extends Component {
                                      onDurationSet={(duration) => this.onDurationSet(duration)}
                         />
                         <div className={cx("big-play-button", {
-                            "hidden": this.state.playing || this.state.position !== 0
+                            "hidden": this.state.playing || this.state.position > 0.1
                         })}
                              onClick={() => this.play()}
                         >
-                            <FiPlay size="32px"/>
+                            <FiPlay size={32} fill="#f00" viewBox="-2 0 24 24" />
                         </div>
                     </SplitView>
 

--- a/src/util/HlsUtils.js
+++ b/src/util/HlsUtils.js
@@ -18,12 +18,12 @@ export async function parseHlsManifest(url) {
             bandwidth: playlist.attributes.BANDWIDTH,
             ...playlist.attributes.RESOLUTION,
         };
-    }).sort((a, b) => a.bandwidth - b.bandwidth);
+    }).sort((a, b) => b.bandwidth - a.bandwidth);
 
     return {
         mainUrl: url,
         variants,
-        selectedVariant: variants.length - 1,
+        selectedVariant: 0,
     };
 }
 

--- a/src/util/HlsUtils.js
+++ b/src/util/HlsUtils.js
@@ -18,11 +18,12 @@ export async function parseHlsManifest(url) {
             bandwidth: playlist.attributes.BANDWIDTH,
             ...playlist.attributes.RESOLUTION,
         };
-    });
+    }).sort((a, b) => a.bandwidth - b.bandwidth);
+
     return {
         mainUrl: url,
         variants,
-        selectedVariant: 0
+        selectedVariant: variants.length - 1,
     };
 }
 


### PR DESCRIPTION
The variant list in the UI has the variants in the order that they appear in the manifest, but HLS.js is sorting them by bitrate in ascending order - this means that the variant changing mechanism potentially switches to a different variant than the one the user selected (unless the manifest is ordered that way already, which it often is). This sorts the the list in the same way.