### PR TITLE
Analyze with mediainfo instead of mp4box. Report load progress

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,5 +36,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <!-- mediainfo used to parse metadata for dropped files and URL media -->
+    <script type="text/javascript" src="https://unpkg.com/mediainfo.js"></script>
   </body>
 </html>

--- a/src/components/VideoViewer/VideoPlayer.js
+++ b/src/components/VideoViewer/VideoPlayer.js
@@ -105,8 +105,14 @@ class VideoPlayer extends Component {
                 },
                 { once: true });
             if (isHlsPlaylist(url)) {
-                this.loadHls(url, variant)
-            } else if (isDashManifest(url)) {
+                this.loadHls(url, variant); 
+                return;
+            } else if (this.state.hls) {
+                this.state.hls.detachMedia();
+                this.setState({hls: null});
+            }
+
+            if (isDashManifest(url)) {
                 this.loadDash(url, variant);
             } else {
                 this.videoElement.src = url;
@@ -124,10 +130,6 @@ class VideoPlayer extends Component {
     }
 
     loadDash(url, variant) {
-        if (this.state.hls) {
-            this.state.hls.detachMedia();
-            this.setState({hls: null});
-        }
         let dash = this.state.dash;
         this.videoElement.addEventListener('canplay',
             () => {

--- a/src/components/VideoViewer/index.js
+++ b/src/components/VideoViewer/index.js
@@ -13,7 +13,6 @@ import {openFullscreen, isFullscreen, closeFullscreen} from "../../util/Fullscre
 import {copyToClipboard} from "../../util/CopyClipboard";
 import {FiPlay} from 'react-icons/fi';
 import cx from 'classnames';
-import {isHlsPlaylist} from "../../util/HlsUtils";
 import {isDashOrHls, sourceType} from "../../util/SourceUtils";
 
 const DEFAULT_SOURCES = {

--- a/src/util/MediaInfo.js
+++ b/src/util/MediaInfo.js
@@ -1,0 +1,75 @@
+// eslint-disable-next-line no-undef
+const mediaInfoFactory = globalThis.MediaInfo.default;
+const mediainfo = await mediaInfoFactory({chunkSize: 10 * 1024 * 1024});
+let reportProgressFn = () => {};
+
+export async function getMediaInfo(source, reportProgress) {
+    if (reportProgress) {
+        reportProgressFn = reportProgress;
+    }
+
+    if (source.type === 'file') {
+        // https://github.com/buzz/mediainfo.js/blob/8a9a9f2d3540261ea3bebdf8bcea1f0c443d55fa/examples/browser-umd/example.js#L13
+        const file = source.file;
+        let loadedSize = 0;
+        const readFileChunk = async (chunkSize, offset) => {
+            loadedSize += chunkSize;
+            reportProgressFn(`${((loadedSize / file.size) * 100).toFixed(2)}%`);
+            return new Uint8Array(await file.slice(offset, offset + chunkSize).arrayBuffer());
+        };
+        const result = await mediainfo.analyzeData(file.size, readFileChunk);
+        console.log('mediainfo result', result);
+        mediainfo.close();
+        return result;
+    }
+
+    // source.type === 'url'
+    const result = await mediainfo.analyzeData(getUrlMediaSize(source.url), readUrlChunk(source.url));
+    console.log('mediainfo result', result);
+    mediainfo.close();
+    return result;
+}
+
+let totalSize = 0;
+let loadedSize = 0;
+
+const getUrlMediaSize = url => async () => {
+    const response = await fetch(url, {method: 'HEAD'});
+    const length = response.ok ? parseInt(response.headers.get('Content-Length') ?? '0', 10) : 0;
+
+    if (length) {
+        totalSize = parseInt(length, 10);
+    } else {
+        console.error("HEAD request doesn't provide a Content-Length");
+        // 6GB absolute max for range fetching.
+        // Most likely won't use this as readUrlChunk should quit when done.
+        totalSize = 5 * 1024 * 1024 * 1024;
+    }
+    return totalSize;
+};
+
+const readUrlChunk = url => async (chunkSize, offset) => {
+    if (chunkSize === 0) return new Uint8Array();
+
+    const from = offset;
+    const to = offset + chunkSize;
+    const start = to < from ? to : from;
+    const end = to < from ? from : to;
+
+    const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+            Range: `bytes=${start}-${end}`,
+        },
+    });
+
+    loadedSize += end - start;
+    reportProgressFn(`${((loadedSize / totalSize) * 100).toFixed(2)}%`);
+
+    if (!response.ok) {
+        // Probably end of the file. Return empty to stop fetching/reading
+        console.warn(`HTTP error status=${response.status}: ${response.statusText}`);
+        return new Uint8Array();
+    }
+    return new Uint8Array(await response.arrayBuffer());
+};


### PR DESCRIPTION
I often drag in files over a network share. In these cases the app needs to load the entire file for mp4box, which meant 2GB+ coming over the network..


I've used https://mediaarea.net/MediaCompare a bunch and knew it instantly provided metadata in these same cases, so I tried adopting `mediainfo` within vivict.. It works surprisingly well; it only needs to read the beginning of media files (usually 1-4% of large multi-GB files), saving a lot of time. 

But another bonus:  it handles **non-mp4 assets like mkv, webm**, etc. :)  So, we get that for free. 🥳 

Minor: I also added a lil mechanism to report file loading progress to the UI for feedback. Works on file drop, file select, and media URL. 
<img width="207" alt="image" src="https://github.com/user-attachments/assets/a923b4a2-3823-481c-b02a-6c39f18bbc86">
